### PR TITLE
feat: add Builder::out_dir to set output directory

### DIFF
--- a/pbjson-build/src/lib.rs
+++ b/pbjson-build/src/lib.rs
@@ -107,6 +107,18 @@ impl Builder {
         }
     }
 
+    /// Configures the output directory where generated Rust files will be written.
+    ///
+    /// If unset, defaults to the `OUT_DIR` environment variable. `OUT_DIR` is set by Cargo when
+    /// executing build scripts, so `out_dir` typically does not need to be configured.
+    pub fn out_dir<P>(&mut self, path: P) -> &mut Self
+    where
+        P: Into<PathBuf>,
+    {
+        self.out_dir = Some(path.into());
+        self
+    }
+
     /// Register an encoded `FileDescriptorSet` with this `Builder`
     pub fn register_descriptors(&mut self, descriptors: &[u8]) -> Result<&mut Self> {
         self.descriptors.register_encoded(descriptors)?;


### PR DESCRIPTION
# Rationale
Allow overriding the output directory, as does tonic_build, lets us target different locations for building

Add an API mirroring `tonic_build ` to explicitly override the output directory

See reference https://docs.rs/tonic-build/0.5.2/tonic_build/struct.Builder.html#method.out_dir

# Changes:
copy/paste implementation from tonic-build:https://docs.rs/tonic-build/0.5.2/src/tonic_build/prost.rs.html#261-267
