### PR TITLE
feat: fix resolver (#9)

### DIFF
--- a/pbjson-build/src/descriptor.rs
+++ b/pbjson-build/src/descriptor.rs
@@ -13,23 +13,36 @@ use prost_types::{
 };
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-pub struct Package(String);
+pub struct Package {
+    path: Vec<TypeName>,
+}
 
 impl Display for Package {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
+        write!(f, "{}", self.path[0])?;
+        for element in &self.path[1..self.path.len()] {
+            write!(f, ".{}", element)?;
+        }
+        Ok(())
     }
 }
 
 impl Package {
-    pub fn new(s: impl Into<String>) -> Self {
-        let s = s.into();
+    pub fn new(s: impl AsRef<str>) -> Self {
+        let s = s.as_ref();
         assert!(
             !s.starts_with('.'),
             "package cannot start with \'.\', got \"{}\"",
             s
         );
-        Self(s)
+
+        Self {
+            path: s.split('.').map(TypeName::new).collect(),
+        }
+    }
+
+    pub fn path(&self) -> &[TypeName] {
+        self.path.as_slice()
     }
 }
 
@@ -97,8 +110,14 @@ impl TypePath {
         &self.package
     }
 
-    pub fn path(&self) -> &[TypeName] {
-        self.path.as_slice()
+    /// Returns the length of the path
+    pub fn len(&self) -> usize {
+        self.path.len() + self.package.path.len()
+    }
+
+    /// Returns the full path
+    pub fn path(&self) -> impl Iterator<Item = &'_ TypeName> + '_ {
+        self.package.path().iter().chain(self.path.iter())
     }
 
     pub fn child(&self, name: TypeName) -> Self {
@@ -108,36 +127,34 @@ impl TypePath {
             .cloned()
             .chain(std::iter::once(name))
             .collect();
+
         Self {
             package: self.package.clone(),
             path,
         }
     }
 
-    pub fn matches_prefix(&self, prefix: &str) -> bool {
+    /// Performs a prefix match, returning the length of the match in path segments if any
+    pub fn prefix_match(&self, prefix: &str) -> Option<usize> {
         let prefix = match prefix.strip_prefix('.') {
             Some(prefix) => prefix,
-            None => return false,
+            None => panic!("prefix must start with a '.'"),
         };
 
-        if prefix.len() <= self.package.0.len() {
-            return self.package.0.starts_with(prefix);
+        if prefix.is_empty() {
+            return Some(0);
         }
 
-        match prefix.strip_prefix(&self.package.0) {
-            Some(prefix) => {
-                let split = prefix.split('.').skip(1);
-                for zipped in self.path.iter().zip_longest(split) {
-                    match zipped {
-                        EitherOrBoth::Both(a, b) if a.0.as_str() == b => continue,
-                        EitherOrBoth::Left(_) => return true,
-                        _ => return false,
-                    }
-                }
-                true
+        let mut match_len = 0_usize;
+        let split = prefix.split('.');
+        for zipped in self.path().zip_longest(split) {
+            match zipped {
+                EitherOrBoth::Both(a, b) if a.0.as_str() == b => match_len += 1,
+                EitherOrBoth::Left(_) => return Some(match_len),
+                _ => return None,
             }
-            None => false,
         }
+        Some(match_len)
     }
 }
 
@@ -256,5 +273,27 @@ impl MessageDescriptor {
             .as_ref()
             .and_then(|options| options.map_entry)
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_prefix_match() {
+        let t = TypePath::new(Package::new("foo.bar"))
+            .child(TypeName::new("Baz"))
+            .child(TypeName::new("Bar"));
+
+        assert_eq!(t.prefix_match("."), Some(0));
+        assert_eq!(t.prefix_match(".."), None);
+        assert_eq!(t.prefix_match(".foo"), Some(1));
+        assert_eq!(t.prefix_match(".foo."), None);
+        assert_eq!(t.prefix_match(".foo.bar"), Some(2));
+        assert_eq!(t.prefix_match(".foo.bar.Bar"), None);
+        assert_eq!(t.prefix_match(".foo.bar.Baz"), Some(3));
+        assert_eq!(t.prefix_match(".foo.bar.Baza"), None);
+        assert_eq!(t.prefix_match(".foo.bar.Baz.Bar"), Some(4));
+        assert_eq!(t.prefix_match(".foo.bar.Baz.Bar.Boo"), None);
     }
 }

--- a/pbjson-build/src/generator.rs
+++ b/pbjson-build/src/generator.rs
@@ -1,10 +1,7 @@
 //! This module contains the actual code generation logic
 
-use std::collections::BTreeMap;
 use std::fmt::{Display, Formatter};
 use std::io::{Result, Write};
-
-use crate::descriptor::TypePath;
 
 mod enumeration;
 mod message;
@@ -21,51 +18,6 @@ impl Display for Indent {
             write!(f, "    ")?;
         }
         Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub struct Config {
-    pub extern_types: BTreeMap<TypePath, String>,
-}
-
-impl Config {
-    fn rust_type(&self, path: &TypePath) -> String {
-        if let Some(t) = self.extern_types.get(path) {
-            return t.clone();
-        }
-
-        let mut ret = String::new();
-        let path = path.path();
-        assert!(!path.is_empty(), "path cannot be empty");
-
-        for i in &path[..(path.len() - 1)] {
-            ret.push_str(i.to_snake_case().as_str());
-            ret.push_str("::");
-        }
-        ret.push_str(path.last().unwrap().to_camel_case().as_str());
-        ret
-    }
-
-    fn rust_variant(&self, enumeration: &TypePath, variant: &str) -> String {
-        use heck::CamelCase;
-        assert!(
-            variant
-                .chars()
-                .all(|c| matches!(c, '0'..='9' | 'A'..='Z' | '_')),
-            "illegal variant - {}",
-            variant
-        );
-
-        // TODO: Config to disable stripping prefix
-
-        let enumeration_name = enumeration.path().last().unwrap().to_shouty_snake_case();
-        let variant = match variant.strip_prefix(&enumeration_name) {
-            Some("") => variant,
-            Some(stripped) => stripped,
-            None => variant,
-        };
-        variant.to_camel_case()
     }
 }
 

--- a/pbjson-build/src/generator/enumeration.rs
+++ b/pbjson-build/src/generator/enumeration.rs
@@ -6,26 +6,27 @@
 
 use super::{
     write_deserialize_end, write_deserialize_start, write_serialize_end, write_serialize_start,
-    Config, Indent,
+    Indent,
 };
 use crate::descriptor::{EnumDescriptor, TypePath};
 use crate::generator::write_fields_array;
+use crate::resolver::Resolver;
 use std::io::{Result, Write};
 
 pub fn generate_enum<W: Write>(
-    config: &Config,
+    resolver: &Resolver<'_>,
     path: &TypePath,
     descriptor: &EnumDescriptor,
     writer: &mut W,
 ) -> Result<()> {
-    let rust_type = config.rust_type(path);
+    let rust_type = resolver.rust_type(path);
 
     let variants: Vec<_> = descriptor
         .values
         .iter()
         .map(|variant| {
             let variant_name = variant.name.clone().unwrap();
-            let rust_variant = config.rust_variant(path, &variant_name);
+            let rust_variant = resolver.rust_variant(path, &variant_name);
             (variant_name, rust_variant)
         })
         .collect();

--- a/pbjson-build/src/message.rs
+++ b/pbjson-build/src/message.rs
@@ -246,7 +246,7 @@ fn resolve_type(descriptors: &DescriptorSet, type_name: &str) -> FieldType {
     );
     let maybe_descriptor = descriptors
         .iter()
-        .find(|(path, _)| path.matches_prefix(type_name));
+        .find(|(path, _)| path.prefix_match(type_name).is_some());
 
     match maybe_descriptor {
         Some((path, Descriptor::Enum(_))) => FieldType::Enum(path.clone()),

--- a/pbjson-build/src/resolver.rs
+++ b/pbjson-build/src/resolver.rs
@@ -1,0 +1,175 @@
+use crate::descriptor::{Package, TypePath};
+
+#[derive(Debug)]
+pub struct Resolver<'a> {
+    extern_types: &'a [(String, String)],
+    package: &'a Package,
+}
+
+impl<'a> Resolver<'a> {
+    /// Creates a new resolver for `package`
+    pub fn new(extern_types: &'a [(String, String)], package: &'a Package) -> Self {
+        Resolver {
+            extern_types,
+            package,
+        }
+    }
+
+    /// Lookup an extern type, returns the rust type followed by the remaining
+    /// number of path segments to skip
+    fn resolve_extern(&self, path: &TypePath) -> Option<(String, usize)> {
+        let mut match_len = 0_usize;
+        let mut match_idx = None;
+
+        for (idx, (proto_path, _)) in self.extern_types.iter().enumerate() {
+            match path.prefix_match(proto_path) {
+                Some(m) if m >= match_len => {
+                    match_idx = Some(idx);
+                    match_len = m;
+                }
+                _ => {}
+            }
+        }
+
+        let (_, rust_path) = &self.extern_types[match_idx?];
+
+        if match_len == path.len() {
+            Some((rust_path.clone(), match_len))
+        } else {
+            Some((format!("{}::", rust_path), match_len))
+        }
+    }
+
+    /// Returns the rust type for `path` relative to `cur`
+    pub fn rust_type(&self, path: &TypePath) -> String {
+        let (mut ret, skip) = match self.resolve_extern(path) {
+            Some(x) => x,
+            None => {
+                // Compute the amount the resolver and path have in common
+                let shared_prefix = self
+                    .package
+                    .path()
+                    .iter()
+                    .zip(path.path())
+                    .filter(|(a, b)| a == b)
+                    .count();
+
+                let super_count = self.package.path().len() - shared_prefix;
+
+                let mut ret = String::new();
+                for _ in 0..super_count {
+                    ret.push_str("super::")
+                }
+
+                (ret, shared_prefix)
+            }
+        };
+
+        let mut iter = path.path().skip(skip).peekable();
+        while let Some(i) = iter.next() {
+            match iter.peek() {
+                Some(_) => {
+                    ret.push_str(i.to_snake_case().as_str());
+                    ret.push_str("::");
+                }
+                None => {
+                    ret.push_str(i.to_camel_case().as_str());
+                }
+            }
+        }
+        ret
+    }
+
+    pub fn rust_variant(&self, enumeration: &TypePath, variant: &str) -> String {
+        use heck::CamelCase;
+        assert!(
+            variant
+                .chars()
+                .all(|c| matches!(c, '0'..='9' | 'A'..='Z' | '_')),
+            "illegal variant - {}",
+            variant
+        );
+
+        // TODO: Config to disable stripping prefix
+
+        let enumeration_name = enumeration.path().last().unwrap().to_shouty_snake_case();
+        let variant = match variant.strip_prefix(&enumeration_name) {
+            Some("") => variant,
+            Some(stripped) => stripped,
+            None => variant,
+        };
+        variant.to_camel_case()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::descriptor::TypeName;
+
+    #[test]
+    fn test_resolver() {
+        let resolver_package = Package::new("test.syntax3");
+        let extern_types = &[
+            (".test.external".to_string(), "foo::common".to_string()),
+            (".test.external.Boo".to_string(), "foo::common".to_string()),
+            (
+                ".test.external.Fiz.Buz".to_string(),
+                "foo::bar::Buz".to_string(),
+            ),
+        ];
+        let resolver = Resolver::new(extern_types, &resolver_package);
+
+        // A type in the same package
+        let same_type = TypePath::new(resolver_package.clone()).child(TypeName::new("Foo"));
+        assert_eq!(resolver.rust_type(&same_type), "Foo");
+
+        let nested_type = TypePath::new(resolver_package.clone())
+            .child(TypeName::new("Foo"))
+            .child(TypeName::new("Bar"));
+
+        assert_eq!(resolver.rust_type(&nested_type), "foo::Bar");
+
+        let other_package = Package::new("test.common");
+
+        // A type in another package
+        let other_type = TypePath::new(other_package.clone()).child(TypeName::new("Bar"));
+        assert_eq!(resolver.rust_type(&other_type), "super::common::Bar");
+
+        let other_nested_type = TypePath::new(other_package)
+            .child(TypeName::new("Foo"))
+            .child(TypeName::new("Bar"));
+
+        assert_eq!(
+            resolver.rust_type(&other_nested_type),
+            "super::common::foo::Bar"
+        );
+
+        let external_package = Package::new("test.external");
+
+        // An external type
+        let external_type = TypePath::new(external_package.clone()).child(TypeName::new("Fiz"));
+        assert_eq!(resolver.rust_type(&external_type), "foo::common::Fiz");
+
+        // A nested external type
+        let nested_external_type = external_type.child(TypeName::new("Bar"));
+
+        assert_eq!(
+            resolver.rust_type(&nested_external_type),
+            "foo::common::fiz::Bar"
+        );
+
+        // An external type within an external type
+        let external_nested_type = external_type.child(TypeName::new("Buz"));
+        assert_eq!(resolver.rust_type(&external_nested_type), "foo::bar::Buz");
+
+        // An external type with a different rust path length
+        let external_nested_type = TypePath::new(external_package)
+            .child(TypeName::new("Boo"))
+            .child(TypeName::new("Bar"));
+        assert_eq!(
+            resolver.rust_type(&external_nested_type),
+            "foo::common::Bar"
+        );
+    }
+}

--- a/pbjson-build/src/resolver.rs
+++ b/pbjson-build/src/resolver.rs
@@ -15,8 +15,8 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Lookup an extern type, returns the rust type followed by the remaining
-    /// number of path segments to skip
+    /// Lookup an extern type, returns the rust path followed by the number of
+    /// leading path segments to skip (they are already included in the rust path)
     fn resolve_extern(&self, path: &TypePath) -> Option<(String, usize)> {
         let mut match_len = 0_usize;
         let mut match_idx = None;
@@ -40,7 +40,7 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    /// Returns the rust type for `path` relative to `cur`
+    /// Returns the rust type for `path`
     pub fn rust_type(&self, path: &TypePath) -> String {
         let (mut ret, skip) = match self.resolve_extern(path) {
             Some(x) => x,

--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -9,7 +9,7 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 fn main() -> Result<()> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("protos");
 
-    let proto_files = vec![root.join("syntax3.proto")];
+    let proto_files = vec![root.join("syntax3.proto"), root.join("common.proto")];
 
     // Tell cargo to recompile if any of these proto files are changed
     for proto_file in &proto_files {
@@ -21,12 +21,14 @@ fn main() -> Result<()> {
         .file_descriptor_set_path(&descriptor_path)
         .compile_well_known_types()
         .extern_path(".google.protobuf", "::pbjson_types")
+        .extern_path(".test.external", "crate")
         .bytes(&[".test"])
         .compile_protos(&proto_files, &[root])?;
 
     let descriptor_set = std::fs::read(descriptor_path)?;
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_set)?
+        .extern_path(".test.external", "crate")
         .build(&[".test"])?;
 
     Ok(())

--- a/pbjson-test/protos/common.proto
+++ b/pbjson-test/protos/common.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package test.common;
+
+message CommonMessage {
+
+}
+
+enum CommonEnumeration {
+  UNKNOWN = 0;
+  A = 1;
+}

--- a/pbjson-test/protos/external.proto
+++ b/pbjson-test/protos/external.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package test.external;
+
+message ExternMessage {
+
+}
+
+enum ExternEnumeration {
+  UNKNOWN = 0;
+  A = 1;
+}

--- a/pbjson-test/protos/syntax3.proto
+++ b/pbjson-test/protos/syntax3.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package test.syntax3;
 
+import "common.proto";
+import "external.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -75,4 +77,12 @@ message KitchenSink {
 
   google.protobuf.Duration duration = 37;
   google.protobuf.Timestamp timestamp = 38;
+
+  // An externally defined message
+  test.external.ExternMessage external_message = 39;
+  test.external.ExternEnumeration external_enum = 40;
+
+  // Messages from an external package
+  test.common.CommonMessage common_message = 41;
+  test.common.CommonEnumeration common_enum = 42;
 }

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -1,11 +1,45 @@
-include!(concat!(env!("OUT_DIR"), "/test.syntax3.rs"));
-include!(concat!(env!("OUT_DIR"), "/test.syntax3.serde.rs"));
+use serde::{Deserialize, Serialize};
+
+/// A test of an externally defined message
+#[derive(Clone, PartialEq, ::prost::Message, Serialize, Deserialize)]
+pub struct ExternMessage {}
+
+/// A test of an externally defined enumeration
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    ::prost::Enumeration,
+    Serialize,
+    Deserialize,
+)]
+#[repr(i32)]
+pub enum ExternEnumeration {
+    Unknown = 0,
+}
+
+pub mod test {
+    pub mod syntax3 {
+        include!(concat!(env!("OUT_DIR"), "/test.syntax3.rs"));
+        include!(concat!(env!("OUT_DIR"), "/test.syntax3.serde.rs"));
+    }
+    pub mod common {
+        include!(concat!(env!("OUT_DIR"), "/test.common.rs"));
+        include!(concat!(env!("OUT_DIR"), "/test.common.serde.rs"));
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use chrono::TimeZone;
     use pbjson_types::{Duration, Timestamp};
+    use test::syntax3::*;
 
     #[test]
     fn test_empty() {


### PR DESCRIPTION
This adds support for extern_types, whilst also fixing a bug in the type resolution that would cause invalid code generation for field serializers of enumerations defined in different packages.

Closes #9
