### PR TITLE
Add serde support for Value

### DIFF
--- a/pbjson-types/build.rs
+++ b/pbjson-types/build.rs
@@ -32,6 +32,9 @@ fn main() -> Result<()> {
             ".google.protobuf.Duration",
             ".google.protobuf.Timestamp",
             ".google.protobuf.Value",
+            ".google.protobuf.Struct",
+            ".google.protobuf.ListValue",
+            ".google.protobuf.NullValue",
         ])
         .build(&[".google"])?;
 

--- a/pbjson-types/build.rs
+++ b/pbjson-types/build.rs
@@ -28,7 +28,11 @@ fn main() -> Result<()> {
     let descriptor_set = std::fs::read(descriptor_path)?;
     pbjson_build::Builder::new()
         .register_descriptors(&descriptor_set)?
-        .exclude([".google.protobuf.Duration", ".google.protobuf.Timestamp"])
+        .exclude([
+            ".google.protobuf.Duration",
+            ".google.protobuf.Timestamp",
+            ".google.protobuf.Value",
+        ])
         .build(&[".google"])?;
 
     Ok(())

--- a/pbjson-types/src/lib.rs
+++ b/pbjson-types/src/lib.rs
@@ -24,6 +24,7 @@
     clippy::redundant_closure,
     clippy::redundant_field_names,
     clippy::clone_on_ref_ptr,
+    clippy::enum_variant_names,
     clippy::use_self
 )]
 mod pb {
@@ -36,6 +37,9 @@ mod pb {
 }
 
 mod duration;
+mod list_value;
+mod r#struct;
 mod timestamp;
+mod value;
 
 pub use pb::google::protobuf::*;

--- a/pbjson-types/src/lib.rs
+++ b/pbjson-types/src/lib.rs
@@ -38,8 +38,9 @@ mod pb {
 
 mod duration;
 mod list_value;
+mod null_value;
 mod r#struct;
 mod timestamp;
-mod value;
+pub mod value;
 
 pub use pb::google::protobuf::*;

--- a/pbjson-types/src/list_value.rs
+++ b/pbjson-types/src/list_value.rs
@@ -1,0 +1,27 @@
+impl From<Vec<crate::Value>> for crate::ListValue {
+    fn from(values: Vec<crate::Value>) -> Self {
+        Self { values }
+    }
+}
+
+impl FromIterator<crate::value::Kind> for crate::ListValue {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = crate::value::Kind>,
+    {
+        Self {
+            values: iter.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl FromIterator<crate::Value> for crate::ListValue {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = crate::Value>,
+    {
+        Self {
+            values: iter.into_iter().collect(),
+        }
+    }
+}

--- a/pbjson-types/src/list_value.rs
+++ b/pbjson-types/src/list_value.rs
@@ -1,10 +1,20 @@
-impl From<Vec<crate::Value>> for crate::ListValue {
+use crate::ListValue;
+
+impl From<Vec<crate::Value>> for ListValue {
     fn from(values: Vec<crate::Value>) -> Self {
         Self { values }
     }
 }
 
-impl FromIterator<crate::value::Kind> for crate::ListValue {
+impl<const N: usize> From<[crate::Value; N]> for ListValue {
+    fn from(values: [crate::Value; N]) -> Self {
+        Self {
+            values: values.into(),
+        }
+    }
+}
+
+impl FromIterator<crate::value::Kind> for ListValue {
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = crate::value::Kind>,
@@ -15,7 +25,7 @@ impl FromIterator<crate::value::Kind> for crate::ListValue {
     }
 }
 
-impl FromIterator<crate::Value> for crate::ListValue {
+impl FromIterator<crate::Value> for ListValue {
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = crate::Value>,
@@ -23,5 +33,63 @@ impl FromIterator<crate::Value> for crate::ListValue {
         Self {
             values: iter.into_iter().collect(),
         }
+    }
+}
+
+impl serde::Serialize for ListValue {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.values.serialize(ser)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for ListValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(ListValueVisitor)
+    }
+}
+
+struct ListValueVisitor;
+
+impl<'de> serde::de::Visitor<'de> for ListValueVisitor {
+    type Value = ListValue;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("google.protobuf.ListValue")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::SeqAccess<'de>,
+    {
+        let mut list = Vec::new();
+
+        while let Some(value) = seq.next_element()? {
+            list.push(value);
+        }
+
+        Ok(list.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::Value;
+
+    #[test]
+    fn list_value() {
+        assert_eq!(
+            serde_json::to_value(Value::from([false.into(), true.into(), false.into()])).unwrap(),
+            serde_json::json!([false, true, false])
+        );
+        assert_eq!(
+            serde_json::to_value(Value::from(true)).unwrap(),
+            serde_json::json!(true)
+        );
     }
 }

--- a/pbjson-types/src/list_value.rs
+++ b/pbjson-types/src/list_value.rs
@@ -82,6 +82,14 @@ mod tests {
     use crate::Value;
 
     #[test]
+    fn mixed_types() {
+        assert_eq!(
+            serde_json::to_value(Value::from([true.into(), "HELLO".into(), false.into()])).unwrap(),
+            serde_json::json!([true, "HELLO", false])
+        );
+    }
+
+    #[test]
     fn list_value() {
         assert_eq!(
             serde_json::to_value(Value::from([false.into(), true.into(), false.into()])).unwrap(),

--- a/pbjson-types/src/null_value.rs
+++ b/pbjson-types/src/null_value.rs
@@ -1,0 +1,42 @@
+use crate::NullValue;
+
+impl From<()> for NullValue {
+    fn from(_: ()) -> Self {
+        Self::NullValue
+    }
+}
+
+impl serde::Serialize for NullValue {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        ().serialize(ser)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for NullValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_unit(NullValueVisitor)
+    }
+}
+
+struct NullValueVisitor;
+
+impl<'de> serde::de::Visitor<'de> for NullValueVisitor {
+    type Value = NullValue;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("google.protobuf.NullValue")
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(NullValue::NullValue)
+    }
+}

--- a/pbjson-types/src/struct.rs
+++ b/pbjson-types/src/struct.rs
@@ -1,0 +1,48 @@
+impl From<std::collections::HashMap<String, crate::Value>> for crate::Struct {
+    fn from(fields: std::collections::HashMap<String, crate::Value>) -> Self {
+        Self { fields }
+    }
+}
+
+impl FromIterator<(String, crate::Value)> for crate::Struct {
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = (String, crate::Value)>,
+    {
+        Self {
+            fields: iter.into_iter().collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let map = std::collections::HashMap::from([
+            (String::from("bool"), true.into()),
+            (String::from("unit"), crate::value::Kind::NullValue(0)),
+            (String::from("number"), 5.0.into()),
+            (String::from("string"), "string".into()),
+            (String::from("list"), vec![1.0.into(), 2.0.into()].into()),
+            (
+                String::from("map"),
+                std::collections::HashMap::from([(String::from("key"), "value".into())]).into(),
+            ),
+        ]);
+
+        assert_eq!(
+            serde_json::to_value(map).unwrap(),
+            serde_json::json!({
+                "bool": true,
+                "unit": null,
+                "number": 5.0,
+                "string": "string",
+                "list": [1.0, 2.0],
+                "map": {
+                    "key": "value",
+                }
+            })
+        );
+    }
+}

--- a/pbjson-types/src/struct.rs
+++ b/pbjson-types/src/struct.rs
@@ -1,10 +1,12 @@
-impl From<std::collections::HashMap<String, crate::Value>> for crate::Struct {
+use crate::Struct;
+
+impl From<std::collections::HashMap<String, crate::Value>> for Struct {
     fn from(fields: std::collections::HashMap<String, crate::Value>) -> Self {
         Self { fields }
     }
 }
 
-impl FromIterator<(String, crate::Value)> for crate::Struct {
+impl FromIterator<(String, crate::Value)> for Struct {
     fn from_iter<T>(iter: T) -> Self
     where
         T: IntoIterator<Item = (String, crate::Value)>,
@@ -15,13 +17,57 @@ impl FromIterator<(String, crate::Value)> for crate::Struct {
     }
 }
 
+impl serde::Serialize for Struct {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.fields.serialize(ser)
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Struct {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(StructVisitor)
+    }
+}
+
+struct StructVisitor;
+
+impl<'de> serde::de::Visitor<'de> for StructVisitor {
+    type Value = Struct;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("google.protobuf.Struct")
+    }
+
+    fn visit_map<A>(self, mut map_access: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        let mut map = std::collections::HashMap::new();
+
+        while let Some((key, value)) = map_access.next_entry()? {
+            map.insert(key, value);
+        }
+
+        Ok(map.into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
     fn it_works() {
-        let map = std::collections::HashMap::from([
-            (String::from("bool"), true.into()),
-            (String::from("unit"), crate::value::Kind::NullValue(0)),
+        let map: crate::Struct = std::collections::HashMap::from([
+            (String::from("bool"), crate::Value::from(true)),
+            (
+                String::from("unit"),
+                crate::value::Kind::NullValue(0).into(),
+            ),
             (String::from("number"), 5.0.into()),
             (String::from("string"), "string".into()),
             (String::from("list"), vec![1.0.into(), 2.0.into()].into()),
@@ -29,7 +75,8 @@ mod tests {
                 String::from("map"),
                 std::collections::HashMap::from([(String::from("key"), "value".into())]).into(),
             ),
-        ]);
+        ])
+        .into();
 
         assert_eq!(
             serde_json::to_value(map).unwrap(),

--- a/pbjson-types/src/value.rs
+++ b/pbjson-types/src/value.rs
@@ -1,0 +1,317 @@
+pub use crate::pb::google::protobuf::value::Kind;
+
+use serde::{
+    de::{self, MapAccess, SeqAccess},
+    ser, Deserialize, Deserializer, Serialize, Serializer,
+};
+
+macro_rules! from {
+    ($($typ: ty [$id:ident] => {$($from_type:ty => $exp:expr),+ $(,)?})+) => {
+        $($(
+            impl From<$from_type> for $typ {
+                fn from($id: $from_type) -> Self {
+                    $exp
+                }
+            }
+        )+)+
+    }
+}
+
+from! {
+    crate::Value[value] => {
+        bool => Kind::from(value).into(),
+        f64 => Kind::from(value).into(),
+        String => Kind::from(value).into(),
+        &'static str => Kind::from(value).into(),
+        Vec<Self> => Kind::from(value).into(),
+        std::collections::HashMap<String, Self> => Kind::from(value).into(),
+        Kind => Self { kind: Some(value) },
+        Option<Kind> => Self { kind: value },
+    }
+
+    Kind[value] => {
+        bool => Self::BoolValue(value),
+        f64 => Self::NumberValue(value),
+        String => Self::StringValue(value),
+        &'static str => Self::StringValue(value.into()),
+        Vec<crate::Value> => Self::ListValue(value.into()),
+        std::collections::HashMap<String, crate::Value> => Self::StructValue(value.into()),
+    }
+}
+
+impl Serialize for crate::Value {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.kind.serialize(ser)
+    }
+}
+
+impl<'de> Deserialize<'de> for crate::Value {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Self {
+            kind: <_>::deserialize(deserializer)?,
+        })
+    }
+}
+
+impl Serialize for Kind {
+    fn serialize<S>(&self, ser: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::NullValue(_) => ().serialize(ser),
+            Self::StringValue(value) => value.serialize(ser),
+            Self::BoolValue(value) => value.serialize(ser),
+            Self::StructValue(value) => value.fields.serialize(ser),
+            Self::ListValue(list) => list.values.serialize(ser),
+            Self::NumberValue(value) => {
+                // Kind does not allow NaN's or Infinity as they are
+                // indistinguishable from strings.
+                if value.is_nan() {
+                    Err(ser::Error::custom(
+                        "Cannot serialize NaN as google.protobuf.Value.number_value",
+                    ))
+                } else if value.is_infinite() {
+                    Err(ser::Error::custom(
+                        "Cannot serialize infinity as google.protobuf.Value.number_value",
+                    ))
+                } else {
+                    value.serialize(ser)
+                }
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Kind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(KindVisitor)
+    }
+}
+
+struct KindVisitor;
+
+impl<'de> serde::de::Visitor<'de> for KindVisitor {
+    type Value = Kind;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("google.protobuf.Value")
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::BoolValue(v))
+    }
+
+    fn visit_i8<E>(self, v: i8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_i16<E>(self, v: i16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_i32(v.try_into().map_err(de::Error::custom)?)
+    }
+
+    fn visit_i128<E>(self, v: i128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_i32(v.try_into().map_err(de::Error::custom)?)
+    }
+
+    fn visit_u8<E>(self, v: u8) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_u32(v.try_into().map_err(de::Error::custom)?)
+    }
+
+    fn visit_u128<E>(self, v: u128) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_u32(v.try_into().map_err(de::Error::custom)?)
+    }
+
+    fn visit_f32<E>(self, v: f32) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v.into()))
+    }
+
+    fn visit_f64<E>(self, v: f64) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NumberValue(v))
+    }
+
+    fn visit_char<E>(self, v: char) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::StringValue(v.into()))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::StringValue(v.into()))
+    }
+
+    fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::StringValue(v.into()))
+    }
+
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::StringValue(v))
+    }
+
+    fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::ListValue(
+            v.iter()
+                .copied()
+                .map(f64::from)
+                .map(Kind::NumberValue)
+                .collect(),
+        ))
+    }
+
+    fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_bytes(v)
+    }
+
+    fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::ListValue(
+            v.into_iter()
+                .map(f64::from)
+                .map(Kind::NumberValue)
+                .collect(),
+        ))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NullValue(0))
+    }
+
+    fn visit_some<D>(self, de: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Deserialize::deserialize(de)
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(Kind::NullValue(0))
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut list = Vec::new();
+
+        while let Some(value) = seq.next_element()? {
+            list.push(value);
+        }
+
+        Ok(Kind::ListValue(list.into()))
+    }
+
+    fn visit_map<A>(self, mut map_access: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut map = std::collections::HashMap::new();
+
+        while let Some((key, value)) = map_access.next_entry()? {
+            map.insert(key, value);
+        }
+
+        Ok(Kind::StructValue(map.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn float_special_cases() {
+        assert!(serde_json::to_value(crate::Value::from(f64::NAN)).is_err());
+        assert!(serde_json::to_value(crate::Value::from(f64::INFINITY)).is_err());
+        assert!(serde_json::to_value(crate::Value::from(f64::NEG_INFINITY)).is_err());
+    }
+}


### PR DESCRIPTION
This PR adds `serde` support for `google.protobuf.Value`.

closes #5 
Depends on #14 