### PR TITLE
fix: encoding of mixed case enumerations (#15)

### DIFF
--- a/pbjson-build/src/descriptor.rs
+++ b/pbjson-build/src/descriptor.rs
@@ -75,11 +75,6 @@ impl TypeName {
         use heck::CamelCase;
         self.0.to_camel_case()
     }
-
-    pub fn to_shouty_snake_case(&self) -> String {
-        use heck::ShoutySnakeCase;
-        self.0.to_shouty_snake_case()
-    }
 }
 
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -164,10 +159,6 @@ pub struct DescriptorSet {
 }
 
 impl DescriptorSet {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub fn register_encoded(&mut self, encoded: &[u8]) -> Result<()> {
         let descriptors: FileDescriptorSet =
             prost::Message::decode(encoded).map_err(|e| Error::new(ErrorKind::InvalidData, e))?;

--- a/pbjson-test/protos/syntax3.proto
+++ b/pbjson-test/protos/syntax3.proto
@@ -24,6 +24,13 @@ message KitchenSink {
     B = 20;
   }
 
+  enum MixedCase {
+    MixedCaseUnknown = 0;
+    MixedCASEA = 1;
+    MixEdCaseB = 2;
+    c = 3;
+  }
+
   int32 i32 = 1;
   optional int32 optional_i32 = 2;
   repeated int32 repeated_i32 = 3;
@@ -85,4 +92,6 @@ message KitchenSink {
   // Messages from an external package
   test.common.CommonMessage common_message = 41;
   test.common.CommonEnumeration common_enum = 42;
+
+  MixedCase mixed_case = 43;
 }

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -37,6 +37,7 @@ pub mod test {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test::syntax3::kitchen_sink::MixedCase;
     use chrono::TimeZone;
     use pbjson_types::{Duration, Timestamp};
     use test::syntax3::*;
@@ -294,5 +295,17 @@ mod tests {
             nanos: 5049,
         });
         verify(&decoded, r#"{"duration":"40502002.000005049s"}"#);
+
+        decoded.duration = None;
+        verify_decode(&decoded, "{}");
+
+        decoded.mixed_case = MixedCase::MixedCasea as _;
+        verify(&decoded, r#"{"mixedCase":"MixedCASEA"}"#);
+
+        decoded.mixed_case = MixedCase::MixEdCaseB as _;
+        verify(&decoded, r#"{"mixedCase":"MixEdCaseB"}"#);
+
+        decoded.mixed_case = MixedCase::C as _;
+        verify(&decoded, r#"{"mixedCase":"c"}"#);
     }
 }


### PR DESCRIPTION
The current logic to handle enumerations will never generate incorrect serialization code, but will panic if the protobuf definition contains lower case characters. This PR fixes that, and also adds in the ability to disable enum prefix stripping, a feature which prost also has.

The [protobuf spec](https://developers.google.com/protocol-buffers/docs/proto3#json) says that enum variants be encoded as-is in the proto definitions, and so that is what this PR does. If your proto definition has mixed capitalisation, so will your JSON payloads.

This must also follow the same logic used by prost to [strip enum prefixes](https://github.com/tokio-rs/prost/blob/d45a37cab69c2a0cda36a97df8823fcaf43dc1fe/prost-build/src/code_generator.rs#L998) to ensure we generate correct code.

Closes #15 