### PR TITLE
Turn off default features of chrono as they're not needed

### DIFF
--- a/pbjson-types/Cargo.toml
+++ b/pbjson-types/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/influxdata/pbjson"
 
 [dependencies] # In alphabetical order
 bytes = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4", default-features = false }
 pbjson = { path = "../pbjson", version = "0.2" }
 prost = "0.9"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
In fact, the "oldtime" feature is [considered deprecated][1] and only
included by default for backwards compatibility.

The other features don't appear to be used by pbjson-types, so this
gives projects depending on it more flexibility in what they choose
to include.

[1]: https://github.com/chronotope/chrono/blame/f6bd567bb677262645c1fc3131c8c1071cd77ec3/README.md#L88-L94