### PR TITLE
chore: fix chrono feature flag

### DIFF
--- a/pbjson-types/Cargo.toml
+++ b/pbjson-types/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/influxdata/pbjson"
 
 [dependencies] # In alphabetical order
 bytes = "1.0"
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 pbjson = { path = "../pbjson", version = "0.2" }
 prost = "0.9"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This was disabled in #19 but I forgot to check the crates still built independently. The alloc feature is needed for string formatting support