### PR TITLE
feat: support URL-safe base64 strings (#22)

### DIFF
--- a/pbjson/Cargo.toml
+++ b/pbjson/Cargo.toml
@@ -16,3 +16,4 @@ base64 = "0.13"
 
 [dev-dependencies]
 bytes = "1.0"
+rand = "0.8"


### PR DESCRIPTION
There might be smarter ways to detect this, but this was the quickest solution I could come up with.

Closes #22 