### PR TITLE
feat: add support for bytes values in maps (#23)

### DIFF
--- a/pbjson-test/protos/syntax3.proto
+++ b/pbjson-test/protos/syntax3.proto
@@ -76,9 +76,6 @@ message KitchenSink {
   optional bytes optional_bytes = 32;
   repeated bytes repeated_bytes = 33;
 
-  // Bytes support is currently broken - https://github.com/tokio-rs/prost/issues/531
-  //  map<string, bytes> bytes_dict = 34;
-
   string string = 35;
   optional string optional_string = 36;
 
@@ -94,4 +91,10 @@ message KitchenSink {
   test.common.CommonEnumeration common_enum = 42;
 
   MixedCase mixed_case = 43;
+
+  map<string, bytes> string_bytes_dict = 44;
+  map<int32, bytes> int_bytes_dict = 45;
+
+  // https://github.com/influxdata/pbjson/issues/27
+  // map<bool, bytes> bool_bytes_dict = 46;
 }

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -258,14 +258,22 @@ mod tests {
         decoded.repeated_bytes = Default::default();
         verify_decode(&decoded, "{}");
 
-        // decoded.bytes_dict.insert(
-        //     "test".to_string(),
-        //     prost::bytes::Bytes::from_static(b"asdf"),
-        // );
-        // verify(&decoded, r#"{"bytesDict":{"test":"YXNkZgo="}}"#);
-        //
-        // decoded.bytes_dict = Default::default();
-        // verify_decode(&decoded, "{}");
+        decoded.string_bytes_dict.insert(
+            "test".to_string(),
+            prost::bytes::Bytes::from_static(b"asdf"),
+        );
+        verify(&decoded, r#"{"stringBytesDict":{"test":"YXNkZg=="}}"#);
+
+        decoded.string_bytes_dict = Default::default();
+        verify_decode(&decoded, "{}");
+
+        decoded
+            .int_bytes_dict
+            .insert(43, prost::bytes::Bytes::from_static(b"343dfgd"));
+        verify(&decoded, r#"{"intBytesDict":{"43":"MzQzZGZnZA=="}}"#);
+
+        decoded.int_bytes_dict = Default::default();
+        verify_decode(&decoded, "{}");
 
         decoded.string = "test".to_string();
         verify(&decoded, r#"{"string":"test"}"#);


### PR DESCRIPTION
Closes #23 

Whilst implementing this I realised #27 is an issue, but going to punt on fixing that for now. It's not a quick fix, and very niche.