### PR TITLE
correctness fixes to get Envoy xDS protos compiling

### DIFF
--- a/pbjson-build/src/escape.rs
+++ b/pbjson-build/src/escape.rs
@@ -24,3 +24,12 @@ pub fn escape_ident(mut ident: String) -> String {
     };
     ident
 }
+
+/// Converts a `snake_case` identifier to an `UpperCamel` case Rust type identifier.
+pub fn escape_camel_case(mut ident: String) -> String {
+    // Suffix an underscore for the `Self` Rust keyword as it is not allowed as raw identifier.
+    if ident == "Self" {
+        ident += "_";
+    }
+    ident
+}

--- a/pbjson-build/src/escape.rs
+++ b/pbjson-build/src/escape.rs
@@ -26,7 +26,7 @@ pub fn escape_ident(mut ident: String) -> String {
 }
 
 /// Converts a `snake_case` identifier to an `UpperCamel` case Rust type identifier.
-pub fn escape_camel_case(mut ident: String) -> String {
+pub fn escape_type(mut ident: String) -> String {
     // Suffix an underscore for the `Self` Rust keyword as it is not allowed as raw identifier.
     if ident == "Self" {
         ident += "_";

--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -30,6 +30,7 @@ use super::{
     Indent,
 };
 use crate::descriptor::TypePath;
+use crate::escape::escape_camel_case;
 use crate::generator::write_fields_array;
 use crate::resolver::Resolver;
 
@@ -591,7 +592,7 @@ fn write_deserialize_field_name<W: Write>(
                 "{}\"{}\" => Ok(GeneratedField::{}),",
                 Indent(indent + 5),
                 json_name,
-                type_name
+                escape_camel_case(type_name.to_string()),
             )?;
         }
         writeln!(
@@ -631,7 +632,12 @@ fn write_fields_enum<'a, W: Write, I: Iterator<Item = &'a str>>(
     )?;
     writeln!(writer, "{}enum GeneratedField {{", Indent(indent))?;
     for type_name in fields {
-        writeln!(writer, "{}{},", Indent(indent + 1), type_name)?;
+        writeln!(
+            writer,
+            "{}{},",
+            Indent(indent + 1),
+            escape_camel_case(type_name.to_string())
+        )?;
     }
     writeln!(writer, "{}}}", Indent(indent))
 }

--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -30,7 +30,7 @@ use super::{
     Indent,
 };
 use crate::descriptor::TypePath;
-use crate::escape::escape_camel_case;
+use crate::escape::escape_type;
 use crate::generator::write_fields_array;
 use crate::resolver::Resolver;
 
@@ -592,7 +592,7 @@ fn write_deserialize_field_name<W: Write>(
                 "{}\"{}\" => Ok(GeneratedField::{}),",
                 Indent(indent + 5),
                 json_name,
-                escape_camel_case(type_name.to_string()),
+                escape_type(type_name.to_string()),
             )?;
         }
         writeln!(
@@ -636,7 +636,7 @@ fn write_fields_enum<'a, W: Write, I: Iterator<Item = &'a str>>(
             writer,
             "{}{},",
             Indent(indent + 1),
-            escape_camel_case(type_name.to_string())
+            escape_type(type_name.to_string())
         )?;
     }
     writeln!(writer, "{}}}", Indent(indent))

--- a/pbjson-build/src/message.rs
+++ b/pbjson-build/src/message.rs
@@ -10,7 +10,7 @@ use prost_types::{
 };
 
 use crate::descriptor::{Descriptor, DescriptorSet, MessageDescriptor, Syntax, TypeName, TypePath};
-use crate::escape::{escape_camel_case, escape_ident};
+use crate::escape::{escape_type, escape_ident};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ScalarType {
@@ -86,7 +86,7 @@ pub struct Field {
 impl Field {
     pub fn rust_type_name(&self) -> String {
         use heck::ToUpperCamelCase;
-        escape_camel_case(self.name.to_upper_camel_case())
+        escape_type(self.name.to_upper_camel_case())
     }
 
     pub fn rust_field_name(&self) -> String {

--- a/pbjson-build/src/message.rs
+++ b/pbjson-build/src/message.rs
@@ -10,7 +10,7 @@ use prost_types::{
 };
 
 use crate::descriptor::{Descriptor, DescriptorSet, MessageDescriptor, Syntax, TypeName, TypePath};
-use crate::escape::escape_ident;
+use crate::escape::{escape_camel_case, escape_ident};
 
 #[derive(Debug, Clone, Copy)]
 pub enum ScalarType {
@@ -86,7 +86,7 @@ pub struct Field {
 impl Field {
     pub fn rust_type_name(&self) -> String {
         use heck::CamelCase;
-        self.name.to_camel_case()
+        escape_camel_case(self.name.to_camel_case())
     }
 
     pub fn rust_field_name(&self) -> String {

--- a/pbjson-build/src/resolver.rs
+++ b/pbjson-build/src/resolver.rs
@@ -1,5 +1,5 @@
 use crate::descriptor::{Package, TypePath};
-use crate::escape::{escape_camel_case, escape_ident};
+use crate::escape::{escape_type, escape_ident};
 
 #[derive(Debug)]
 pub struct Resolver<'a> {
@@ -80,7 +80,7 @@ impl<'a> Resolver<'a> {
                     ret.push_str("::");
                 }
                 None => {
-                    ret.push_str(escape_camel_case(i.to_upper_camel_case()).as_str());
+                    ret.push_str(escape_type(i.to_upper_camel_case()).as_str());
                 }
             }
         }

--- a/pbjson-build/src/resolver.rs
+++ b/pbjson-build/src/resolver.rs
@@ -116,9 +116,13 @@ mod tests {
         let resolver_package = Package::new("envoy.service.health.v3");
         let resolver = Resolver::new(&[], &resolver_package, false);
 
-        let to_resolve = TypePath::new(Package::new("envoy.config.core.v3")).child(TypeName::new("HealthStatus"));
+        let to_resolve = TypePath::new(Package::new("envoy.config.core.v3"))
+            .child(TypeName::new("HealthStatus"));
 
-        assert_eq!("super::super::super::config::core::v3::HealthStatus", resolver.rust_type(&to_resolve));
+        assert_eq!(
+            "super::super::super::config::core::v3::HealthStatus",
+            resolver.rust_type(&to_resolve)
+        );
     }
 
     #[test]

--- a/pbjson-build/src/resolver.rs
+++ b/pbjson-build/src/resolver.rs
@@ -58,7 +58,7 @@ impl<'a> Resolver<'a> {
                     .path()
                     .iter()
                     .zip(path.path())
-                    .filter(|(a, b)| a == b)
+                    .take_while(|(a, b)| a == b)
                     .count();
 
                 let super_count = self.package.path().len() - shared_prefix;
@@ -110,6 +110,16 @@ impl<'a> Resolver<'a> {
 mod tests {
     use super::*;
     use crate::descriptor::TypeName;
+
+    #[test]
+    fn test_complicated_resolver() {
+        let resolver_package = Package::new("envoy.service.health.v3");
+        let resolver = Resolver::new(&[], &resolver_package, false);
+
+        let to_resolve = TypePath::new(Package::new("envoy.config.core.v3")).child(TypeName::new("HealthStatus"));
+
+        assert_eq!("super::super::super::config::core::v3::HealthStatus", resolver.rust_type(&to_resolve));
+    }
 
     #[test]
     fn test_resolver() {

--- a/pbjson-build/src/resolver.rs
+++ b/pbjson-build/src/resolver.rs
@@ -1,4 +1,5 @@
 use crate::descriptor::{Package, TypePath};
+use crate::escape::{escape_camel_case, escape_ident};
 
 #[derive(Debug)]
 pub struct Resolver<'a> {
@@ -75,11 +76,11 @@ impl<'a> Resolver<'a> {
         while let Some(i) = iter.next() {
             match iter.peek() {
                 Some(_) => {
-                    ret.push_str(i.to_snake_case().as_str());
+                    ret.push_str(escape_ident(i.to_snake_case()).as_str());
                     ret.push_str("::");
                 }
                 None => {
-                    ret.push_str(i.to_camel_case().as_str());
+                    ret.push_str(escape_camel_case(i.to_camel_case()).as_str());
                 }
             }
         }


### PR DESCRIPTION
👋🏻 I'm working to read in some Envoy protobufs, and its a large project with a bunch of corner cases (e.g. fields named `map`, enum values named `self` and with the `allow_alias` option enabled, etc).   The below commits are what I needed to get things at least compiling!