### PR TITLE
pbjson-build: Use `std::result::Result` in the generated code

### DIFF
--- a/pbjson-build/src/generator.rs
+++ b/pbjson-build/src/generator.rs
@@ -39,7 +39,7 @@ fn write_serialize_start<W: Write>(indent: usize, rust_type: &str, writer: &mut 
         writer,
         r#"{indent}impl serde::Serialize for {rust_type} {{
 {indent}    #[allow(deprecated)]
-{indent}    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+{indent}    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
 {indent}    where
 {indent}        S: serde::Serializer,
 {indent}    {{"#,
@@ -62,7 +62,7 @@ fn write_deserialize_start<W: Write>(indent: usize, rust_type: &str, writer: &mu
         writer,
         r#"{indent}impl<'de> serde::Deserialize<'de> for {rust_type} {{
 {indent}    #[allow(deprecated)]
-{indent}    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+{indent}    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
 {indent}    where
 {indent}        D: serde::Deserializer<'de>,
 {indent}    {{"#,

--- a/pbjson-build/src/generator/enumeration.rs
+++ b/pbjson-build/src/generator/enumeration.rs
@@ -82,7 +82,7 @@ fn write_visitor<W: Write>(
 {indent}        write!(formatter, "expected one of: {{:?}}", &FIELDS)
 {indent}    }}
 
-{indent}    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+{indent}    fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
 {indent}    where
 {indent}        E: serde::de::Error,
 {indent}    {{
@@ -95,7 +95,7 @@ fn write_visitor<W: Write>(
 {indent}            }})
 {indent}    }}
 
-{indent}    fn visit_u64<E>(self, v: u64) -> Result<Self::Value, E>
+{indent}    fn visit_u64<E>(self, v: u64) -> std::result::Result<Self::Value, E>
 {indent}    where
 {indent}        E: serde::de::Error,
 {indent}    {{
@@ -108,7 +108,7 @@ fn write_visitor<W: Write>(
 {indent}            }})
 {indent}    }}
 
-{indent}    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+{indent}    fn visit_str<E>(self, value: &str) -> std::result::Result<Self::Value, E>
 {indent}    where
 {indent}        E: serde::de::Error,
 {indent}    {{"#,

--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -440,7 +440,7 @@ fn write_deserialize_message<W: Write>(
 {indent}        formatter.write_str("struct {name}")
 {indent}    }}
 
-{indent}    fn visit_map<V>(self, mut map: V) -> Result<{rust_type}, V::Error>
+{indent}    fn visit_map<V>(self, mut map: V) -> std::result::Result<{rust_type}, V::Error>
 {indent}        where
 {indent}            V: serde::de::MapAccess<'de>,
 {indent}    {{"#,
@@ -563,7 +563,7 @@ fn write_deserialize_field_name<W: Write>(
     writeln!(
         writer,
         r#"{indent}impl<'de> serde::Deserialize<'de> for GeneratedField {{
-{indent}    fn deserialize<D>(deserializer: D) -> Result<GeneratedField, D::Error>
+{indent}    fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
 {indent}    where
 {indent}        D: serde::Deserializer<'de>,
 {indent}    {{
@@ -576,7 +576,7 @@ fn write_deserialize_field_name<W: Write>(
 {indent}                write!(formatter, "expected one of: {{:?}}", &FIELDS)
 {indent}            }}
 
-{indent}            fn visit_str<E>(self, value: &str) -> Result<GeneratedField, E>
+{indent}            fn visit_str<E>(self, value: &str) -> std::result::Result<GeneratedField, E>
 {indent}            where
 {indent}                E: serde::de::Error,
 {indent}            {{"#,


### PR DESCRIPTION
I had a case where `message Result` was defined in the proto files, and generated code was trying to use that instead of Rust's `Result` type.

The solution was to have the full path of `Result` type in the generated code.