### PR TITLE
feat: add flag to skip unknown fields instead of error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,6 +125,9 @@ jobs:
       - run:
           name: Cargo test
           command: cargo test --workspace
+      - run:
+          name: Cargo test (ignore unknown fields)
+          command: cargo test --workspace --features ignore-unknown-fields
       - cache_save
 
 workflows:

--- a/pbjson-build/src/lib.rs
+++ b/pbjson-build/src/lib.rs
@@ -103,6 +103,7 @@ pub struct Builder {
     out_dir: Option<PathBuf>,
     extern_paths: Vec<(String, String)>,
     retain_enum_prefix: bool,
+    ignore_unknown_fields: bool,
 }
 
 impl Builder {
@@ -158,6 +159,14 @@ impl Builder {
     ) -> &mut Self {
         self.extern_paths
             .push((proto_path.into(), rust_path.into()));
+        self
+    }
+
+    /// Don't error out in the presence of unknown fields when deserializing,
+    /// instead skip the field.
+    pub fn ignore_unknown_fields(&mut self) -> &mut Self {
+        self.ignore_unknown_fields = true;
+
         self
     }
 
@@ -238,7 +247,7 @@ impl Builder {
                 }
                 Descriptor::Message(descriptor) => {
                     if let Some(message) = resolve_message(&self.descriptors, descriptor) {
-                        generate_message(&resolver, &message, writer)?
+                        generate_message(&resolver, &message, writer, self.ignore_unknown_fields)?
                     }
                 }
             }

--- a/pbjson-test/Cargo.toml
+++ b/pbjson-test/Cargo.toml
@@ -12,6 +12,9 @@ pbjson = { path = "../pbjson" }
 pbjson-types = { path = "../pbjson-types" }
 serde = { version = "1.0", features = ["derive"] }
 
+[features]
+ignore-unknown-fields = []
+
 [dev-dependencies]
 chrono = "0.4"
 serde_json = "1.0"

--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -26,11 +26,17 @@ fn main() -> Result<()> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&proto_files, &[root])?;
 
-    let descriptor_set = std::fs::read(descriptor_path)?;
-    pbjson_build::Builder::new()
+    let descriptor_set = std::fs::read(&descriptor_path)?;
+    let mut builder = pbjson_build::Builder::new();
+    builder
         .register_descriptors(&descriptor_set)?
-        .extern_path(".test.external", "crate")
-        .build(&[".test"])?;
+        .extern_path(".test.external", "crate");
+
+    if cfg!(feature = "ignore-unknown-fields") {
+        builder.ignore_unknown_fields();
+    }
+
+    builder.build(&[".test"])?;
 
     Ok(())
 }

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -43,7 +43,8 @@ mod tests {
     use test::syntax3::*;
 
     #[test]
-    fn test_empty() {
+    #[cfg(not(feature = "ignore-unknown-fields"))]
+    fn test_unknown_field_error() {
         let message = Empty {};
 
         let encoded = serde_json::to_string(&message).unwrap();
@@ -60,6 +61,18 @@ mod tests {
             err.to_string().as_str(),
             "unknown field `foo`, there are no fields at line 1 column 6"
         );
+    }
+
+    #[test]
+    #[cfg(feature = "ignore-unknown-fields")]
+    fn test_ignore_unknown_field() {
+        let message = Empty {};
+
+        let encoded = serde_json::to_string(&message).unwrap();
+        let _decoded: Empty = serde_json::from_str(&encoded).unwrap();
+
+        let empty = serde_json::from_str::<Empty>("{\n \"foo\": \"bar\"\n}").unwrap();
+        assert_eq!(empty, Empty {});
     }
 
     #[test]


### PR DESCRIPTION
## What?

Allow skipping unknown fields when deserializing.

I added a flag to to the builder, so this behavior is opt-in, keeping
the old behavior (error out for unknown fields) as default.

## Why?

This is mostly required for forward compatibility, when new fields
are added, any old instance will fail to deserialize a message
serialized with a newer version. This is also aligned with prost that
skips any unknown field too.

## How?

Added a special variant `GeneratedField::__SkipField__` that is used every time an unknown field is encountered, which then is used to consume and ignore the value of the field. This will be added only if the `skip_unknown_fields` flag is set.

To set the flag, a new `Builder::skip_unknown_fields` function was added.

## Other notes

I generated the code for the tests twice, to test the skip functionality properly. This may not be the best way as it may not scale, but didn't wanted to impose any particular style on that one. I'm totally open to work it out.