### PR TITLE
chore: compress CI docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,11 @@ jobs:
           name: Cargo doc
           command: cargo doc --document-private-items --no-deps --workspace
       - cache_save
+      - run:
+          name: Compress Docs
+          command: tar -cvzf rustdoc.tar.gz target/doc/
       - store_artifacts:
-          path: target/doc/
-          destination: rustdoc
+          path: rustdoc.tar.gz
 
   test:
     docker:


### PR DESCRIPTION
The docs upload is taking longer than the rest of the CI pipeline. This changes to uploading a compressed tarball which will be significantly faster. For reference the same change was made to IOx last year - https://github.com/influxdata/influxdb_iox/pull/2880