### PR TITLE
chore: prepare 0.3 release

### DIFF
--- a/pbjson-build/Cargo.toml
+++ b/pbjson-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson-build"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 edition = "2021"
 description = "Generates Serialize and Deserialize implementations for prost message types"

--- a/pbjson-test/Cargo.toml
+++ b/pbjson-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson-test"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 edition = "2021"
 description = "Test resources for pbjson converion"

--- a/pbjson-types/Cargo.toml
+++ b/pbjson-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson-types"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 description = "Protobuf well known types with serde serialization support"
 edition = "2021"
@@ -12,7 +12,7 @@ repository = "https://github.com/influxdata/pbjson"
 [dependencies] # In alphabetical order
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-pbjson = { path = "../pbjson", version = "0.2" }
+pbjson = { path = "../pbjson", version = "0.3" }
 prost = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -21,4 +21,4 @@ serde_json = "1.0"
 
 [build-dependencies] # In alphabetical order
 prost-build = "0.10"
-pbjson-build = { path = "../pbjson-build", version = "0.2" }
+pbjson-build = { path = "../pbjson-build", version = "0.3" }

--- a/pbjson/Cargo.toml
+++ b/pbjson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 edition = "2021"
 description = "Utilities for pbjson conversion"


### PR DESCRIPTION
Includes

* https://github.com/influxdata/pbjson/pull/39
* https://github.com/influxdata/pbjson/pull/35

Technically this is not a breaking change in so much as pbjson doesn't have any breaking changes, but it is a breaking prost upgrade so best to follow along given the degree of coupling between the projects.