### PR TITLE
fix: escape field names in generated code (#45) 

### DIFF
--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -461,7 +461,7 @@ fn write_deserialize_message<W: Write>(
     for field in &message.fields {
         writeln!(
             writer,
-            "{}let mut {} = None;",
+            "{}let mut {}__ = None;",
             Indent(indent + 2),
             field.rust_field_name(),
         )?;
@@ -470,7 +470,7 @@ fn write_deserialize_message<W: Write>(
     for one_of in &message.one_ofs {
         writeln!(
             writer,
-            "{}let mut {} = None;",
+            "{}let mut {}__ = None;",
             Indent(indent + 2),
             one_of.rust_field_name(),
         )?;
@@ -531,7 +531,7 @@ fn write_deserialize_message<W: Write>(
             FieldModifier::Required => {
                 writeln!(
                     writer,
-                    "{indent}{field}: {field}.ok_or_else(|| serde::de::Error::missing_field(\"{json_name}\"))?,",
+                    "{indent}{field}: {field}__.ok_or_else(|| serde::de::Error::missing_field(\"{json_name}\"))?,",
                     indent=Indent(indent + 3),
                     field= field.rust_field_name(),
                     json_name= field.json_name()
@@ -541,7 +541,7 @@ fn write_deserialize_message<W: Write>(
                 // Note: this currently does not hydrate optional proto2 fields with defaults
                 writeln!(
                     writer,
-                    "{indent}{field}: {field}.unwrap_or_default(),",
+                    "{indent}{field}: {field}__.unwrap_or_default(),",
                     indent = Indent(indent + 3),
                     field = field.rust_field_name()
                 )?;
@@ -549,7 +549,7 @@ fn write_deserialize_message<W: Write>(
             _ => {
                 writeln!(
                     writer,
-                    "{indent}{field},",
+                    "{indent}{field}: {field}__,",
                     indent = Indent(indent + 3),
                     field = field.rust_field_name()
                 )?;
@@ -559,7 +559,7 @@ fn write_deserialize_message<W: Write>(
     for one_of in &message.one_ofs {
         writeln!(
             writer,
-            "{indent}{field},",
+            "{indent}{field}: {field}__,",
             indent = Indent(indent + 3),
             field = one_of.rust_field_name(),
         )?;
@@ -713,7 +713,7 @@ fn write_deserialize_field<W: Write>(
     )?;
     writeln!(
         writer,
-        "{}if {}.is_some() {{",
+        "{}if {}__.is_some() {{",
         Indent(indent + 1),
         field_name
     )?;
@@ -726,7 +726,7 @@ fn write_deserialize_field<W: Write>(
         json_name
     )?;
     writeln!(writer, "{}}}", Indent(indent + 1))?;
-    write!(writer, "{}{} = Some(", Indent(indent + 1), field_name)?;
+    write!(writer, "{}{}__ = Some(", Indent(indent + 1), field_name)?;
 
     if let Some(one_of) = one_of {
         write!(

--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -9,7 +9,11 @@ type Result<T, E = Error> = std::result::Result<T, E>;
 fn main() -> Result<()> {
     let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("protos");
 
-    let proto_files = vec![root.join("syntax3.proto"), root.join("common.proto")];
+    let proto_files = vec![
+        root.join("syntax3.proto"),
+        root.join("common.proto"),
+        root.join("duplicate_name.proto"),
+    ];
 
     // Tell cargo to recompile if any of these proto files are changed
     for proto_file in &proto_files {

--- a/pbjson-test/protos/duplicate_name.proto
+++ b/pbjson-test/protos/duplicate_name.proto
@@ -1,0 +1,54 @@
+syntax = "proto3";
+
+package test.duplicate_name;
+
+message Message {
+  bool serializer = 1;
+  bool len = 2;
+  bool struct_ser = 3;
+  bool v = 4;
+  bool value = 5;
+  bool deserializer = 6;
+  bool FIELDS = 7;
+  bool formatter = 8;
+  bool map = 9;
+  bool k = 10;
+  bool variant = 11;
+
+  bool test = 20;
+}
+
+message Oneof {
+  oneof oneof {
+    bool serializer = 1;
+    bool len = 2;
+    bool struct_ser = 3;
+    bool v = 4;
+    bool value = 5;
+    bool deserializer = 6;
+    bool FIELDS = 7;
+    bool formatter = 8;
+    bool map = 9;
+    bool k = 10;
+    bool variant = 11;
+
+    bool test = 20;
+  }
+}
+
+enum Enum {
+  UNSPECIFIED = 0;
+  serializer = 1;
+  len = 2;
+  struct_ser = 3;
+  v = 4;
+  value = 5;
+  deserializer = 6;
+  FIELDS = 7;
+  formatter = 8;
+  map = 9;
+  k = 10;
+  variant = 11;
+
+  test = 20;
+}

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -32,6 +32,10 @@ pub mod test {
         include!(concat!(env!("OUT_DIR"), "/test.common.rs"));
         include!(concat!(env!("OUT_DIR"), "/test.common.serde.rs"));
     }
+    pub mod duplicate_name {
+        include!(concat!(env!("OUT_DIR"), "/test.duplicate_name.rs"));
+        include!(concat!(env!("OUT_DIR"), "/test.duplicate_name.serde.rs"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
#45 
Adding Suffix `__` for the variable which named by `proto field`.

Notice: can't add Prefix, beacuse of `__r#type` is invalid.