### PR TITLE
chore: Update prost, prost-types and prost-build dependencies

### DIFF
--- a/pbjson-build/Cargo.toml
+++ b/pbjson-build/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/influxdata/pbjson"
 [dependencies]
 
 heck = "0.4"
-prost = "0.10"
-prost-types = "0.10"
+prost = "0.11"
+prost-types = "0.11"
 itertools = "0.10"
 
 [dev-dependencies]

--- a/pbjson-test/Cargo.toml
+++ b/pbjson-test/Cargo.toml
@@ -7,7 +7,7 @@ description = "Test resources for pbjson converion"
 repository = "https://github.com/influxdata/pbjson"
 
 [dependencies]
-prost = "0.10"
+prost = "0.11"
 pbjson = { path = "../pbjson" }
 pbjson-types = { path = "../pbjson-types" }
 serde = { version = "1.0", features = ["derive"] }
@@ -21,5 +21,5 @@ chrono = "0.4"
 serde_json = "1.0"
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = "0.11"
 pbjson-build = { path = "../pbjson-build" }

--- a/pbjson-types/Cargo.toml
+++ b/pbjson-types/Cargo.toml
@@ -13,12 +13,12 @@ repository = "https://github.com/influxdata/pbjson"
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 pbjson = { path = "../pbjson", version = "0.3" }
-prost = "0.10"
+prost = "0.11"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 serde_json = "1.0"
 
 [build-dependencies] # In alphabetical order
-prost-build = "0.10"
+prost-build = "0.11"
 pbjson-build = { path = "../pbjson-build", version = "0.3" }


### PR DESCRIPTION
This updates the dependencies on `prost`, `prost-types` and `prost-build` to the latest released version of prost.

As a user of `pbjson` and `pbjson-types` this change to the pbjson crates is necessary when trying to use the recently released `tonic` v0.8.0 along with the pbjson crates, as tonic has been updated to depend on this newer version of the prost crates.

Can this change be included in your release of pbjson v0.4.0? #54 