### PR TITLE
fix: properly handle deserialization from Reader

### DIFF
--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -63,7 +63,16 @@ mod tests {
     }
 
     fn verify_decode(decoded: &KitchenSink, expected: &str) {
+        // Decode from a string first
         assert_eq!(decoded, &serde_json::from_str(expected).unwrap());
+
+        // Then, try decoding from a Reader: this can catch issues when trying to borrow data
+        // from the input, which is not possible when deserializing from a Reader (e.g. an opened
+        // file).
+        assert_eq!(
+            decoded,
+            &serde_json::from_reader(expected.as_bytes()).unwrap()
+        );
     }
 
     fn verify(decoded: &KitchenSink, expected: &str) {


### PR DESCRIPTION
The pattern "let s: &str = Deserialize::deserialize(deser)" used in multiple places is not ideal, as it generates errors when the deserializer uses an IO Reader and not a string. To fix this, implementing a visitor is preferred, as it gives the deserializer the choice of allocating or not a string.

To ensure the issue is fixed, the tests now deserialize both from a string and from a reader.

I haven't used the same fix for the integer/string deserialization for numbers. Using a Visitor is much more cumbersome as it would depend on each numeric type, and using a Cow type is enough to fix the issue.

Closes #55