### PR TITLE
fix: use correct Rust variant name for enum aliases

### DIFF
--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -14,6 +14,7 @@ fn main() -> Result<()> {
         root.join("common.proto"),
         root.join("duplicate_name.proto"),
         root.join("escape.proto"),
+        root.join("enum_alias.proto"),
     ];
 
     // Tell cargo to recompile if any of these proto files are changed

--- a/pbjson-test/protos/enum_alias.proto
+++ b/pbjson-test/protos/enum_alias.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+package test.enum_alias;
+
+enum Enum {
+    option allow_alias = true;
+    VALUE = 0;
+    OTHER = 1;
+    TWO = 2;
+    DOS = 2;
+    value = 0;
+    alias = 0;
+}

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -49,6 +49,11 @@ pub mod test {
             "/test.r#abstract.r#type.escape.serde.rs"
         ));
     }
+
+    pub mod enum_alias {
+        include!(concat!(env!("OUT_DIR"), "/test.enum_alias.rs"));
+        include!(concat!(env!("OUT_DIR"), "/test.enum_alias.serde.rs"));
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This change fixes code generation of protobuf enums when aliases are present.