### PR TITLE
chore: fix two cases where std::result::Result is not fully scoped

### DIFF
--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -262,7 +262,7 @@ fn write_serialize_variable<W: Write>(
                     writeln!(writer)?;
                     write!(
                         writer,
-                        "{}}}).collect::<Result<Vec<_>, _>>()",
+                        "{}}}).collect::<std::result::Result<Vec<_>, _>>()",
                         Indent(indent + 1)
                     )
                 }
@@ -316,7 +316,7 @@ fn write_serialize_variable<W: Write>(
                     writeln!(writer, "{}Ok((k, v))", Indent(indent + 2))?;
                     writeln!(
                         writer,
-                        "{}}}).collect::<Result<_,_>>()?;",
+                        "{}}}).collect::<std::result::Result<_,_>>()?;",
                         Indent(indent + 1)
                     )?;
                 }


### PR DESCRIPTION
This avoids compilation errors where the source proto files declare a `Result` type.