### PR TITLE
chore: update dependencies: heck to `0.5` and itertools to `0.13.0` 

### DIFF
--- a/pbjson-build/Cargo.toml
+++ b/pbjson-build/Cargo.toml
@@ -10,10 +10,10 @@ categories = ["encoding"]
 repository = "https://github.com/influxdata/pbjson"
 
 [dependencies]
-heck = "0.4"
+heck = "0.5"
 prost = "0.13"
 prost-types = "0.13"
-itertools = "0.11"
+itertools = "0.13"
 
 [dev-dependencies]
 tempfile = "3.1"


### PR DESCRIPTION
~Draft as it builds on https://github.com/influxdata/pbjson/pull/128~

# Rationale
As part of preparing a new release, https://github.com/influxdata/pbjson/issues/127 let's update the other dependencies 🎉 

# Changes
1. Update itertools and heck dependencies