### PR TITLE
chore: Prepare `0.7.0` release

### DIFF
--- a/pbjson-build/Cargo.toml
+++ b/pbjson-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson-build"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 edition = "2021"
 description = "Generates Serialize and Deserialize implementations for prost message types"

--- a/pbjson-test/Cargo.toml
+++ b/pbjson-test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson-test"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 edition = "2021"
 description = "Test resources for pbjson converion"

--- a/pbjson-types/Cargo.toml
+++ b/pbjson-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson-types"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 description = "Protobuf well known types with serde serialization support"
 edition = "2021"
@@ -13,7 +13,7 @@ exclude = ["protos/*"]
 [dependencies] # In alphabetical order
 bytes = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-pbjson = { path = "../pbjson", version = "0.6" }
+pbjson = { path = "../pbjson", version = "0.7" }
 prost = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 
@@ -22,4 +22,4 @@ serde_json = "1.0"
 
 [build-dependencies] # In alphabetical order
 prost-build = "0.13"
-pbjson-build = { path = "../pbjson-build", version = "0.6" }
+pbjson-build = { path = "../pbjson-build", version = "0.7" }

--- a/pbjson/Cargo.toml
+++ b/pbjson/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbjson"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
 edition = "2021"
 description = "Utilities for pbjson conversion"


### PR DESCRIPTION
Rationale: prepare for https://github.com/influxdata/pbjson/issues/127

Modeled after https://github.com/influxdata/pbjson/pull/112 from @tustvold 

I don't really have a great idea if updating to a new prost dependency https://github.com/influxdata/pbjson/pull/126 constitutes a breaking API change but let's play it safe and assume so and pump the pre-release major version
