### PR TITLE
fix: handle default value for pb2 enums without a 0 value

### DIFF
--- a/pbjson-build/src/generator.rs
+++ b/pbjson-build/src/generator.rs
@@ -39,6 +39,7 @@ fn write_serialize_start<W: Write>(indent: usize, rust_type: &str, writer: &mut 
         writer,
         r#"{indent}impl serde::Serialize for {rust_type} {{
 {indent}    #[allow(deprecated)]
+{indent}    #[allow(unused_variables)]
 {indent}    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
 {indent}    where
 {indent}        S: serde::Serializer,

--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -264,12 +264,15 @@ fn write_serialize_variable<W: Write>(
                         writer,
                         "{}}}).collect::<std::result::Result<Vec<_>, _>>()",
                         Indent(indent + 1)
-                    )
+                    )?;
+                    writeln!(writer, "?")
                 }
-                _ => write_decode_variant(resolver, indent + 1, variable.as_unref, path, writer),
+                _ => {
+                    write!(writer, "self.{}()", field.rust_field_name())
+                }
             }?;
 
-            writeln!(writer, "?;")?;
+            writeln!(writer, ";")?;
             writeln!(
                 writer,
                 "{}struct_ser.serialize_field(\"{}\", &v)?;",


### PR DESCRIPTION
- Fixed the issue where pb2 enums might not have a 0 value.
- Ensured that when a 0 value exists, pb2 defaults to the first enum value.
- Updated pbjson-build to handle enum value conversion using prost field methods instead of try_from.
- Resolved the serde::ser::Error::custom(format!(\"Invalid variant {{}}\", {}))) error.