### PR TITLE
chore: update itertools to 0.14

### DIFF
--- a/pbjson-build/Cargo.toml
+++ b/pbjson-build/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/influxdata/pbjson"
 heck = "0.5"
 prost = "0.13"
 prost-types = "0.13"
-itertools = "0.13"
+itertools = "0.14"
 
 [dev-dependencies]
 tempfile = "3.1"


### PR DESCRIPTION
`prost-build` updated to accept itertools 0.14. Updating here reduce dependencies duplication.