### PR TITLE
Add Builder::emit_struct_field_null to output null

### DIFF
--- a/pbjson-build/src/lib.rs
+++ b/pbjson-build/src/lib.rs
@@ -108,6 +108,7 @@ pub struct Builder {
     emit_fields: bool,
     use_integers_for_enums: bool,
     preserve_proto_field_names: bool,
+    emit_struct_field_null: bool,
 }
 
 impl Builder {
@@ -200,6 +201,12 @@ impl Builder {
         self
     }
 
+    /// Output optional struct fields with None value as "null", instead of omitted.
+    pub fn emit_struct_field_null(&mut self) -> &mut Self {
+        self.emit_struct_field_null = true;
+        self
+    }
+
     /// Generates code for all registered types where `prefixes` contains a prefix of
     /// the fully-qualified path of the type
     pub fn build<S: AsRef<str>>(&mut self, prefixes: &[S]) -> Result<()> {
@@ -289,6 +296,7 @@ impl Builder {
                             &self.btree_map_paths,
                             self.emit_fields,
                             self.preserve_proto_field_names,
+                            self.emit_struct_field_null,
                         )?
                     }
                 }


### PR DESCRIPTION
Motivation: in some typescript schema libraries, null and undefined are different type. If field type is defined as null, missed field breaks schema validation.

This PR adds flag `emit_struct_field_null` to control whether to emit null for None value of optional fields.

