### PR TITLE
feat: add ignore_unknown_enum_variants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -142,6 +142,9 @@ jobs:
       - run:
           name: Cargo test (preserve proto field names)
           command: cargo test --workspace --features preserve-proto-field-names
+      - run:
+          name: Cargo test (ignore unknown enum variants)
+          command: cargo test --workspace --features ignore-unknown-enum-variants
       - cache_save
 
   vendor:

--- a/pbjson-build/src/lib.rs
+++ b/pbjson-build/src/lib.rs
@@ -107,6 +107,7 @@ pub struct Builder {
     btree_map_paths: Vec<String>,
     emit_fields: bool,
     use_integers_for_enums: bool,
+    ignore_unknown_enum_variants: bool,
     preserve_proto_field_names: bool,
 }
 
@@ -193,6 +194,12 @@ impl Builder {
         self
     }
 
+    /// Ignore unknown enum variants, and instead return the enum default.
+    pub fn ignore_unknown_enum_variants(&mut self) -> &mut Self {
+        self.ignore_unknown_enum_variants = true;
+        self
+    }
+
     /// Output fields with their original names as defined in their proto schemas, instead of
     /// lowerCamelCase
     pub fn preserve_proto_field_names(&mut self) -> &mut Self {
@@ -276,6 +283,7 @@ impl Builder {
                     descriptor,
                     writer,
                     self.use_integers_for_enums,
+                    self.ignore_unknown_enum_variants,
                 )?,
                 Descriptor::Message(descriptor) => {
                     if let Some(message) = resolve_message(&self.descriptors, descriptor) {

--- a/pbjson-test/Cargo.toml
+++ b/pbjson-test/Cargo.toml
@@ -13,6 +13,7 @@ pbjson-types = { path = "../pbjson-types" }
 serde = { version = "1.0", features = ["derive"] }
 
 [features]
+ignore-unknown-enum-variants = []
 ignore-unknown-fields = []
 btree = []
 emit-fields = []

--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -44,6 +44,10 @@ fn main() -> Result<()> {
         .register_descriptors(&descriptor_set)?
         .extern_path(".test.external", "crate");
 
+    if cfg!(feature = "ignore-unknown-enum-variants") {
+        builder.ignore_unknown_enum_variants();
+    }
+
     if cfg!(feature = "ignore-unknown-fields") {
         builder.ignore_unknown_fields();
     }

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -189,6 +189,33 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "ignore-unknown-enum-variants")]
+    fn test_ignore_unknown_enum_variant() {
+        // A known string still maps correctly.
+        let kitchen_sink =
+            serde_json::from_str::<KitchenSink>("{\n \"value\": \"VALUE_A\"\n}").unwrap();
+        assert!(matches!(kitchen_sink, KitchenSink { value: 45, .. }));
+
+        // A known integer still maps correctly.
+        let kitchen_sink = serde_json::from_str::<KitchenSink>("{\n \"value\": 63\n}").unwrap();
+        assert!(matches!(kitchen_sink, KitchenSink { value: 63, .. }));
+
+        // An unknown string maps to default.
+        let kitchen_sink =
+            serde_json::from_str::<KitchenSink>("{\n \"value\": \"VALUE_DOES_NOT_EXIST\"\n}")
+                .unwrap();
+        assert!(matches!(kitchen_sink, KitchenSink { value: 0, .. }));
+
+        // An unknown integer maps to default.
+        let kitchen_sink = serde_json::from_str::<KitchenSink>("{\n \"value\": 1337\n}").unwrap();
+        assert!(matches!(kitchen_sink, KitchenSink { value: 0, .. }));
+
+        // Numeric values that don't fit in an i32 should still error.
+        assert!(serde_json::from_str::<KitchenSink>("{\n \"value\": 5.6\n}").is_err());
+        assert!(serde_json::from_str::<KitchenSink>("{\n \"value\": 3000000000\n}").is_err());
+    }
+
+    #[test]
     #[cfg(feature = "btree")]
     fn test_btree() {
         use std::collections::BTreeMap;


### PR DESCRIPTION
This adds an option to ignore unknown enum variants on deserialization. This allows for better forward compatibility, as decoding JSON with newer enum values no longer fails, but instead defaults the enum values (typically set to UNSPECIFIED/UNKNOWN).

Add a test feature and tests specifically around this feature.

The related issue: https://github.com/influxdata/pbjson/issues/92