### PR TITLE
Aidan/support unknown fields

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ itertools = "0.14"
 pbjson = { path = "pbjson", version = "0.8" }
 pbjson-build = { path = "pbjson-build", version = "0.8" }
 pbjson-types = { path = "pbjson-types", version = "0.8" }
-prost = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "8579f8b" }
-prost-build = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "8579f8b" }
-prost-types = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "8579f8b" }
+prost = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "d20b25c7ad45182da894ed7a559f869360c4bc36" }
+prost-build = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "d20b25c7ad45182da894ed7a559f869360c4bc36" }
+prost-types = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "d20b25c7ad45182da894ed7a559f869360c4bc36" }
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ itertools = "0.14"
 pbjson = { path = "pbjson", version = "0.8" }
 pbjson-build = { path = "pbjson-build", version = "0.8" }
 pbjson-types = { path = "pbjson-types", version = "0.8" }
-prost = "0.14"
-prost-build = "0.14"
-prost-types = "0.14"
+prost = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "8579f8b" }
+prost-build = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "8579f8b" }
+prost-types = { git = "https://github.com/blizzardfinnegan/prost.git", rev = "8579f8b" }
 rand = "0.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/pbjson-build/src/generator/message.rs
+++ b/pbjson-build/src/generator/message.rs
@@ -42,6 +42,7 @@ pub fn generate_message<W: Write>(
     btree_map_paths: &[String],
     emit_fields: bool,
     preserve_proto_field_names: bool,
+    unknown_field_storage_field: &Option<String>,
 ) -> Result<()> {
     let rust_type = resolver.rust_type(&message.path);
 
@@ -67,6 +68,7 @@ pub fn generate_message<W: Write>(
         writer,
         ignore_unknown_fields,
         btree_map_paths,
+        unknown_field_storage_field,
     )?;
     write_deserialize_end(0, writer)?;
     Ok(())
@@ -514,6 +516,7 @@ fn write_deserialize_message<W: Write>(
     writer: &mut W,
     ignore_unknown_fields: bool,
     btree_map_paths: &[String],
+    unknown_field_storage_field: &Option<String>,
 ) -> Result<()> {
     write_deserialize_field_name(2, message, writer, ignore_unknown_fields)?;
 
@@ -652,6 +655,15 @@ fn write_deserialize_message<W: Write>(
             "{indent}{field}: {field}__,",
             indent = Indent(indent + 3),
             field = one_of.rust_field_name(),
+        )?;
+    }
+
+    if let Some(unknown_field_storage_field) = unknown_field_storage_field {
+        writeln!(
+            writer,
+            "{indent}{unknown_field_field}: Default::default(),",
+            indent = Indent(indent + 3),
+            unknown_field_field = unknown_field_storage_field
         )?;
     }
 

--- a/pbjson-build/src/lib.rs
+++ b/pbjson-build/src/lib.rs
@@ -109,7 +109,7 @@ pub struct Builder {
     use_integers_for_enums: bool,
     ignore_unknown_enum_variants: bool,
     preserve_proto_field_names: bool,
-    unknown_field_storage_field: Option<String>,
+    unknown_fields_storage_field: Option<String>,
 }
 
 impl Builder {
@@ -210,10 +210,8 @@ impl Builder {
 
     /// Store unknown fields in the specified field when constructing.
     /// This field is used when using prost generated code with unknown_field support
-    pub fn unknown_field_storage_field<S: Into<String>>(
-        &mut self, field_name: S,
-    ) -> &mut Self {
-        self.unknown_field_storage_field = Some(field_name.into());
+    pub fn unknown_fields_storage_field<S: Into<String>>(&mut self, field_name: S) -> &mut Self {
+        self.unknown_fields_storage_field = Some(field_name.into());
         self
     }
 
@@ -305,7 +303,7 @@ impl Builder {
                             &self.btree_map_paths,
                             self.emit_fields,
                             self.preserve_proto_field_names,
-                            &self.unknown_field_storage_field,
+                            &self.unknown_fields_storage_field,
                         )?
                     }
                 }

--- a/pbjson-build/src/lib.rs
+++ b/pbjson-build/src/lib.rs
@@ -109,6 +109,7 @@ pub struct Builder {
     use_integers_for_enums: bool,
     ignore_unknown_enum_variants: bool,
     preserve_proto_field_names: bool,
+    unknown_field_storage_field: Option<String>,
 }
 
 impl Builder {
@@ -207,6 +208,15 @@ impl Builder {
         self
     }
 
+    /// Store unknown fields in the specified field when constructing.
+    /// This field is used when using prost generated code with unknown_field support
+    pub fn unknown_field_storage_field<S: Into<String>>(
+        &mut self, field_name: S,
+    ) -> &mut Self {
+        self.unknown_field_storage_field = Some(field_name.into());
+        self
+    }
+
     /// Generates code for all registered types where `prefixes` contains a prefix of
     /// the fully-qualified path of the type
     pub fn build<S: AsRef<str>>(&mut self, prefixes: &[S]) -> Result<()> {
@@ -295,6 +305,7 @@ impl Builder {
                             &self.btree_map_paths,
                             self.emit_fields,
                             self.preserve_proto_field_names,
+                            &self.unknown_field_storage_field,
                         )?
                     }
                 }

--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -30,7 +30,8 @@ fn main() -> Result<()> {
         .extern_path(".google.protobuf", "::pbjson_types")
         .extern_path(".test.external", "crate")
         .bytes([".test"])
-        .protoc_arg("--experimental_allow_proto3_optional");
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .include_unknown_fields(".", Some("__unknown_fields"));
 
     if cfg!(feature = "btree") {
         prost_config.btree_map([".test"]);
@@ -67,6 +68,8 @@ fn main() -> Result<()> {
     if cfg!(feature = "preserve-proto-field-names") {
         builder.preserve_proto_field_names();
     }
+
+    builder.unknown_fields_storage_field("__unknown_fields");
 
     builder.build(&[".test"])?;
 

--- a/pbjson-test/build.rs
+++ b/pbjson-test/build.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
         .extern_path(".test.external", "crate")
         .bytes([".test"])
         .protoc_arg("--experimental_allow_proto3_optional")
-        .include_unknown_fields(".", Some("__unknown_fields"));
+        .include_unknown_fields(".", "_unknown_fields");
 
     if cfg!(feature = "btree") {
         prost_config.btree_map([".test"]);
@@ -69,7 +69,7 @@ fn main() -> Result<()> {
         builder.preserve_proto_field_names();
     }
 
-    builder.unknown_fields_storage_field("__unknown_fields");
+    builder.unknown_fields_storage_field("_unknown_fields");
 
     builder.build(&[".test"])?;
 

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -181,13 +181,20 @@ mod tests {
     #[test]
     #[cfg(feature = "ignore-unknown-fields")]
     fn test_ignore_unknown_field() {
-        let message = Empty {};
+        let message = Empty {
+            ..Default::default()
+        };
 
         let encoded = serde_json::to_string(&message).unwrap();
         let _decoded: Empty = serde_json::from_str(&encoded).unwrap();
 
         let empty = serde_json::from_str::<Empty>("{\n \"foo\": \"bar\"\n}").unwrap();
-        assert_eq!(empty, Empty {});
+        assert_eq!(
+            empty,
+            Empty {
+                ..Default::default()
+            }
+        );
     }
 
     #[test]

--- a/pbjson-test/src/lib.rs
+++ b/pbjson-test/src/lib.rs
@@ -158,7 +158,9 @@ mod tests {
     #[test]
     #[cfg(not(feature = "ignore-unknown-fields"))]
     fn test_unknown_field_error() {
-        let message = Empty {};
+        let message = Empty {
+            ..Default::default()
+        };
 
         let encoded = serde_json::to_string(&message).unwrap();
         let _decoded: Empty = serde_json::from_str(&encoded).unwrap();
@@ -787,12 +789,17 @@ mod tests {
     fn test_escaped() -> Result<(), Box<dyn Error>> {
         use super::test::escape::{Abstract, Target, Type};
 
-        let r#type = Type { example: true };
+        let r#type = Type {
+            example: true,
+            ..Default::default()
+        };
         let r#abstract = Abstract {
             r#type: Some(r#type),
+            ..Default::default()
         };
         let target = Target {
             r#abstract: Some(r#abstract),
+            ..Default::default()
         };
 
         let encoded = serde_json::to_string(&target)?;


### PR DESCRIPTION
This is not intended to go in as is, but is some work I started to support a [possible upcoming feature](https://github.com/tokio-rs/prost/pull/1340) that I've been using in a project.

The feature adds unknown field tracking as an option to prost, and does so by adding a public struct member with a configurable name. To make pbjson work correctly with this change, pbjson must be updated to set that struct field to default when constructing.

Protobuf JSON does not maintain unknown fields, so there's no work to do in parsing or data management, just a configurable option that a user can use to set the field they are using with their prost generated code.

I enabled it for testing, and everything passed.

Another option is to just add a boolean `unknown_field_support`, and then generate a `..Default::default()` for the struct creation.