### PR TITLE
chore: move crate metadata & dependencies to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,28 @@ members = [
 ]
 
 resolver = "2"
+
+[workspace.package]
+version = "0.8.0"
+edition = "2021"
+license = "MIT"
+keywords = ["protobuf", "json", "serde"]
+categories = ["encoding"]
+repository = "https://github.com/influxdata/pbjson"
+
+[workspace.dependencies]
+base64 = "0.22"
+bytes = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
+heck = "0.5"
+itertools = "0.14"
+pbjson = { path = "pbjson", version = "0.8" }
+pbjson-build = { path = "pbjson-build", version = "0.8" }
+pbjson-types = { path = "pbjson-types", version = "0.8" }
+prost = "0.14"
+prost-build = "0.14"
+prost-types = "0.14"
+rand = "0.9"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tempfile = "3.1"

--- a/pbjson-build/Cargo.toml
+++ b/pbjson-build/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "pbjson-build"
-version = "0.8.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository.workspace = true
 description = "Generates Serialize and Deserialize implementations for prost message types"
-license = "MIT"
-keywords = ["protobuf", "json", "serde"]
-categories = ["encoding"]
-repository = "https://github.com/influxdata/pbjson"
 
 [dependencies]
-heck = "0.5"
-prost = "0.14"
-prost-types = "0.14"
-itertools = "0.14"
+heck.workspace = true
+prost.workspace = true
+prost-types.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
-tempfile = "3.1"
+tempfile.workspace = true

--- a/pbjson-test/Cargo.toml
+++ b/pbjson-test/Cargo.toml
@@ -1,16 +1,18 @@
 [package]
 name = "pbjson-test"
-version = "0.8.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository.workspace = true
 description = "Test resources for pbjson converion"
-repository = "https://github.com/influxdata/pbjson"
 
 [dependencies]
-prost = "0.14"
-pbjson = { path = "../pbjson" }
-pbjson-types = { path = "../pbjson-types" }
-serde = { version = "1.0", features = ["derive"] }
+prost.workspace = true
+pbjson.workspace = true
+pbjson-types.workspace = true
+serde.workspace = true
 
 [features]
 ignore-unknown-enum-variants = []
@@ -21,9 +23,9 @@ use-integers-for-enums = []
 preserve-proto-field-names = []
 
 [dev-dependencies]
-chrono = "0.4"
-serde_json = "1.0"
+chrono.workspace = true
+serde_json.workspace = true
 
 [build-dependencies]
-prost-build = "0.14"
-pbjson-build = { path = "../pbjson-build" }
+prost-build.workspace = true
+pbjson-build.workspace = true

--- a/pbjson-types/Cargo.toml
+++ b/pbjson-types/Cargo.toml
@@ -1,25 +1,24 @@
 [package]
 name = "pbjson-types"
-version = "0.8.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository.workspace = true
 description = "Protobuf well known types with serde serialization support"
-edition = "2021"
-license = "MIT"
-keywords = ["protobuf", "json", "serde"]
-categories = ["encoding"]
-repository = "https://github.com/influxdata/pbjson"
 exclude = ["protos/*"]
 
 [dependencies] # In alphabetical order
-bytes = "1.0"
-chrono = { version = "0.4", default-features = false, features = ["alloc"] }
-pbjson = { path = "../pbjson", version = "0.8" }
-prost = "0.14"
-serde = { version = "1.0", features = ["derive"] }
+bytes.workspace = true
+chrono.workspace = true
+pbjson.workspace = true
+prost.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true
 
 [build-dependencies] # In alphabetical order
-prost-build = "0.14"
-pbjson-build = { path = "../pbjson-build", version = "0.8" }
+prost-build.workspace = true
+pbjson-build.workspace = true

--- a/pbjson/Cargo.toml
+++ b/pbjson/Cargo.toml
@@ -1,19 +1,17 @@
 [package]
 name = "pbjson"
-version = "0.8.0"
-authors = ["Raphael Taylor-Davies <r.taylordavies@googlemail.com>"]
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+keywords.workspace = true
+categories.workspace = true
+repository.workspace = true
 description = "Utilities for pbjson conversion"
-license = "MIT"
-keywords = ["protobuf", "json", "serde"]
-categories = ["encoding"]
-repository = "https://github.com/influxdata/pbjson"
 
 [dependencies]
-
-serde = { version = "1.0", features = ["derive"] }
-base64 = "0.22"
+base64.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
-bytes = "1.0"
-rand = "0.9"
+bytes.workspace = true
+rand.workspace = true


### PR DESCRIPTION
Also removes the `authors` fields as per [Rust RFC 3052] and <https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field>.

[Rust RFC 3052]: https://rust-lang.github.io/rfcs/3052-optional-authors-field.html